### PR TITLE
Add getDocumentOperations to api

### DIFF
--- a/crdt/api/get_document_operations.js
+++ b/crdt/api/get_document_operations.js
@@ -1,0 +1,8 @@
+import DocumentStore from '../stores/document';
+
+/*
+ * API Name: getDocumentOperations
+ * Returns: An array of operations to get to where the document is currently
+ * Used for setting up a new agent
+ */
+export default () => DocumentStore.getDocument().getOperations();

--- a/crdt/api/index.js
+++ b/crdt/api/index.js
@@ -1,5 +1,6 @@
 import applyOperations from './apply_operations';
 import getDocumentText from './get_document_text';
+import getDocumentOperations from './get_document_operations';
 import replicateDocument from './replicate_document';
 import setDocument from './set_document';
 import setTextInRange from './set_text_in_range';
@@ -7,6 +8,7 @@ import setTextInRange from './set_text_in_range';
 export default {
     applyOperations,
     getDocumentText,
+    getDocumentOperations,
     replicateDocument,
     setDocument,
     setTextInRange,


### PR DESCRIPTION
`getDocumentOperations` will be used to send over all of a document's operations to a new agent for set up