### PR TITLE
Allow for initialization and reinitialization of tandem agent in same vim session

### DIFF
--- a/plugins/vim/tandem.vim
+++ b/plugins/vim/tandem.vim
@@ -80,7 +80,7 @@ def error():
 
 class TandemPlugin:
 
-    def initialize(self):
+    def _initialize(self):
         self._buffer = vim.current.buffer[:]
 
         self._input_checker = Thread(target=self._check_buffer)
@@ -291,7 +291,7 @@ class TandemPlugin:
             self._host_ip = host_ip
             self._host_port = host_port
 
-        self.initialize()
+        self._initialize()
         self._start_agent()
         is_active = True
 


### PR DESCRIPTION
You can't `start` a `Thread` you have previously `join`ed. So, we should reinitialize the thread objects when we stop and start tandem again in the same vim session.
