### PR TITLE
Simplify start/stop vim commands

### DIFF
--- a/plugins/vim/tandem.vim
+++ b/plugins/vim/tandem.vim
@@ -297,7 +297,7 @@ class TandemPlugin:
 
         self._initialize()
 
-        if host_ip is not None:  # assert(host_port is not None)
+        if host_ip is not None:
             self._connect_to = (host_ip, host_port)
 
         self._start_agent()


### PR DESCRIPTION
Change commands to:

- `:Tandem` to start the agent
- `:Tandem <ip> <port>` to start agent and connect to another
- `:TandemStop` to stop the agent

The `stop` method will still be called automatically on quit (see autocmd on L285).