### PR TITLE
Fix initial contents regression

### DIFF
--- a/agent/tandem/protocol/interagent/handler.py
+++ b/agent/tandem/protocol/interagent/handler.py
@@ -11,17 +11,21 @@ class InteragentProtocolHandler:
         self._sequence = 0
 
     def handle_new_connection(self, socket, address):
-        self._connection_manager.register_connection(socket, address)
+        try:
+            self._connection_manager.register_connection(socket, address)
 
-        # Send newly connected agent a copy of the document
-        operations = self._document.get_document_operations()
-        if len(operations) == 0:
-            return
-        new_operations_message = im.NewOperations(operations)
-        new_connection = self._connection_manager.get_connection(address)
-        new_connection.write_string_message(
-            im.serialize(new_operations_message),
-        )
+            # Send newly connected agent a copy of the document
+            operations = self._document.get_document_operations()
+            if len(operations) == 0:
+                return
+            new_operations_message = im.NewOperations(operations)
+            new_connection = self._connection_manager.get_connection(address)
+            new_connection.write_string_message(
+                im.serialize(new_operations_message),
+            )
+        except:
+            logging.exception("Exception when handling a new connection:")
+            raise
 
     def handle_message(self, data, sender_address):
         try:

--- a/crdt/api/get_document_operations.js
+++ b/crdt/api/get_document_operations.js
@@ -5,7 +5,4 @@ import DocumentStore from '../stores/document';
  * Returns: An array of operations to get to where the document is currently
  * Used for setting up a new agent
  */
-export default () => {
-  const { textUpdates } = DocumentStore.getDocument().getOperations();
-  return textUpdates;
-}
+export default () => DocumentStore.getDocument().getOperations();


### PR DESCRIPTION
I made the mistake of assuming that text updates were sent under the `textUpdates` key, but this is for patches only and not CRDT update messages. This caused the contents of the shared document to not be sent to a new participant.

This fixes the `get_document_operations()` call and also adds logging to the `handle_new_connection()` method so that we don't get a silent failure when an exception is thrown. This happens because `handle_new_connection()` is scheduled in the thread pool, so any uncaught exceptions are swallowed.