### PR TITLE
ST3 Conform to Protocol - Handle WriteRequest message

### DIFF
--- a/plugins/sublime/tandem.py
+++ b/plugins/sublime/tandem.py
@@ -230,12 +230,8 @@ class TandemPlugin:
             if not isinstance(message, m.ApplyPatches):
                 raise ValueError("Invalid message. Expected ApplyPatches.")
             self._handle_apply_patches(message)
-        except StopIteration:
-            pass
         except ValueError as v:
             raise v
-        finally:
-            self._text_applied.set()
 
     def _handle_apply_patches(self, message):
         for patch in message.patch_list:
@@ -279,6 +275,7 @@ class TandemPlugin:
             raise v
         finally:
             is_processing = False
+            self._text_applied.set()
 
     def start(self, view, host_ip=None, host_port=None):
         global is_active


### PR DESCRIPTION
Handles the WriteRequest.

The output checker reads the write request, schedules it's handler on the main thread, and blocks on an event.
The handler reads the write request (errors if it receives any other type of message), flushes any pending input buffer changes, sends an ack, and processes the ApplyPatches method. Then it sets the event so that the output checker can continue, and releases control of the main thread.

Tested communication across sublime and vim. Since sublime runs in a GUI, I couldn't test concurrent editing - will have to do this in person.

The first diff in this stack uses the `read_only` flag method, but the most current iteration is the preferred solution, since ideally user keystrokes will be queued and not dropped during processing.