### PR TITLE
[Sublime Text] Disable tandem session menu items when appropriate

### DIFF
--- a/plugins/sublime/tandem.py
+++ b/plugins/sublime/tandem.py
@@ -64,6 +64,10 @@ class TandemCommand(sublime_plugin.TextCommand):
         global tandem_agent
         tandem_agent.start(self.view, host_ip, host_port, show_gui)
 
+    def is_enabled(self):
+        global is_active
+        return not is_active
+
 
 class TandemConnectCommand(sublime_plugin.TextCommand):
     def _start(self, args):
@@ -87,11 +91,19 @@ class TandemConnectCommand(sublime_plugin.TextCommand):
             on_cancel=None,
         )
 
+    def is_enabled(self):
+        global is_active
+        return not is_active
+
 
 class TandemStopCommand(sublime_plugin.TextCommand):
     def run(self, edit, show_gui=False):
         global tandem_agent
         tandem_agent.stop(show_gui)
+
+    def is_enabled(self):
+        global is_active
+        return is_active
 
 
 class TandemPlugin:


### PR DESCRIPTION
https://github.com/geoffxy/tandem/issues/85

The cool thing is, since the command palette commands and menu items invoke the same command, they both are affected by this change. The options automatically filter out of the list when appropriate, and the menu items are also disabled when appropriate. See screens.

<img width="1920" alt="1" src="https://user-images.githubusercontent.com/6415623/35833068-a4fbb50e-0a9d-11e8-93e7-2551a0a7c123.png">
<img width="1920" alt="2" src="https://user-images.githubusercontent.com/6415623/35833070-a51182d0-0a9d-11e8-80f0-08638dd7bb4e.png">
