### PR TITLE
[Vim] Add path of executing vim script to python path

### DIFF
--- a/plugins/vim/tandem_vim.vim
+++ b/plugins/vim/tandem_vim.vim
@@ -19,13 +19,18 @@ com! -nargs=* Tandem py tandem_plugin.start(<f-args>)
 " Stop agent (and disconnect from network) with `:TandemStop`
 com! TandemStop py tandem_plugin.stop(False)
 
+" Get the absolute path to the folder this script resides in, respecting
+" symlinks
+let s:path = fnamemodify(resolve(expand('<sfile>:p')), ':h')
+
 python << EOF
 
 import os
 import sys
 import vim
 
-local_path = os.path.abspath("./")
+# Add the script path to the python path
+local_path = vim.eval("s:path")
 if local_path not in sys.path:
     sys.path.insert(0, local_path)
 


### PR DESCRIPTION
Previously, the path we were adding to the python path (in order for the local python files to be importable) was the path where vim was launched, not the location of the vim script.

The python code alone doesn't know the location of the vim file (`sys.argv[0]` is set to some random value), so we need to resolve the path in vimscript and read it from the python code using `vim.eval`.