### PR TITLE
[Release] Use production npm modules to reduce crdt size

### DIFF
--- a/release_scripts/sublime/prepare.sh
+++ b/release_scripts/sublime/prepare.sh
@@ -46,7 +46,7 @@ $(
   cd $SCRIPT_PATH/../../crdt/;
   npm run clean;
   rm -rf node_modules;
-  npm install;
+  npm install --production;
   npm run build
 )
 cp -r $SCRIPT_PATH/../../crdt/ $INSTALL_PATH/crdt/


### PR DESCRIPTION
This drastically reduces the size of the CRDT deployed form 70 some MB to 3MB.
@geoffxy postulates that removing Winston will also reduce the size further - this can be done in a separate diff.