### PR TITLE
[Release] Clean artifacts and only copy non-dependencies on release

### DIFF
--- a/release_scripts/sublime/prepare.sh
+++ b/release_scripts/sublime/prepare.sh
@@ -53,12 +53,7 @@ $(
   npm install;
   npm run build
 )
-cp -r $SCRIPT_PATH/../../crdt/api/ $INSTALL_PATH/crdt/api/
 cp -r $SCRIPT_PATH/../../crdt/build/ $INSTALL_PATH/crdt/build/
-cp -r $SCRIPT_PATH/../../crdt/io/ $INSTALL_PATH/crdt/io/
-cp -r $SCRIPT_PATH/../../crdt/stores/ $INSTALL_PATH/crdt/stores/
-cp -r $SCRIPT_PATH/../../crdt/utils/ $INSTALL_PATH/crdt/utils/
-cp -r $SCRIPT_PATH/../../crdt/index.js $INSTALL_PATH/crdt/
 
 # Sublime specific files
 cd $SCRIPT_PATH/../../plugins/sublime/

--- a/release_scripts/vim/prepare.sh
+++ b/release_scripts/vim/prepare.sh
@@ -53,12 +53,7 @@ $(
   npm install;
   npm run build
 )
-cp -r $SCRIPT_PATH/../../crdt/api/ $INSTALL_PATH/plugin/tandem_lib/crdt/api/
 cp -r $SCRIPT_PATH/../../crdt/build/ $INSTALL_PATH/plugin/tandem_lib/crdt/build/
-cp -r $SCRIPT_PATH/../../crdt/io/ $INSTALL_PATH/plugin/tandem_lib/crdt/io/
-cp -r $SCRIPT_PATH/../../crdt/stores/ $INSTALL_PATH/plugin/tandem_lib/crdt/stores/
-cp -r $SCRIPT_PATH/../../crdt/utils/ $INSTALL_PATH/plugin/tandem_lib/crdt/utils/
-cp -r $SCRIPT_PATH/../../crdt/index.js $INSTALL_PATH/plugin/tandem_lib/crdt/
 
 # Sublime specific files
 cd $SCRIPT_PATH/../../plugins/vim/


### PR DESCRIPTION
We only need the `build/bundle.js` file to run the CRDT.
so, only copy this and the required files over to the release repository.

Also clean the `.pyc` artifacts from the agent