### PR TITLE
Add rendezvous upstart script

### DIFF
--- a/rendezvous/tandem-rendezvous.conf
+++ b/rendezvous/tandem-rendezvous.conf
@@ -1,0 +1,12 @@
+description "Tandem Rendezvous Server"
+
+start on filesystem or runlevel [2345]
+stop on shutdown
+
+# Respawn on crash but give up after 10 retries within 5 seconds
+respawn
+respawn limit 10 5
+
+exec python3 /home/ec2-user/tandem/rendezvous/main.py \
+  --port 60000 \
+  --log-file /var/log/tandem-rendezvous-$(date +%s).log


### PR DESCRIPTION
This adds an `upstart` script that can be used on the server to keep the rendezvous server running. I've already copied it over and started the server process. For future reference, this file needs to be copied over to `/etc/init` for upstart to be able to find it.

To start the server:
`sudo initctl start tandem-rendezvous`

Restart:
`sudo initctl restart tandem-rendezvous`

Stop:
`sudo initctl stop tandem-rendezvous`

To deploy you would just copy the new code over and run the restart command.