### PR TITLE
Update License to Apache 2.0

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,6 @@
-                       Copyright (c) [2018] [Team Lightly]
-
-                        "Lightly-Modified Apache License"
-                         A Variant of the Apache License
-
-                          View the Apache License at:
+                                 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
-
-                Our license adds clause 4.(e) to the Apache License
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -126,11 +119,6 @@
           or as an addendum to the NOTICE text from the Work, provided
           that such additional attribution notices cannot be construed
           as modifying the License.
-
-     (e) Any Derivative Works may not be configured to use the default server
-         provided by the Copyright holders. You must configure all Derivative
-         Works to use servers owned by You, or servers You are otherwise
-         authorized to use.
 
       You may add Your own copyright statement to Your modifications and
       may provide additional or different license terms and conditions

--- a/README.md
+++ b/README.md
@@ -65,20 +65,27 @@ between agents when this happens.**
 If you wish to disable this behaviour, you can do so by disabling the
 `USE_RELAY` flag in: `agent/tandem/agent/configuration.py`
 
+## Terms of Service
+By using Tandem, you agree that any modified versions of Tandem will not use
+the rendezvous server hosted by the owners. You must host and use your own copy
+of the rendezvous server. We want to provide a good user experience for Tandem,
+and it would be difficult to do that with modified clients as well.
+
+You can launch the rendezvous server by running `python3 ./rendezvous/main.py`.
+Change the address of the rendezvous server used by the agent in the
+configuration file to point to your server's host. This file is located at:
+`agent/tandem/agent/configuration.py`
+
 ## License
 Copyright (c) 2018 Team Lightly
 
-Licensed under the "Lightly-Modified Apache License", a variant of the Apache
-License, Version 2.0 (the "License"); you may not use this file except in
-compliance with the License. 
-
 See [LICENSE.txt](LICENSE.txt)
 
-This license is essentially the Apache License 2.0, except for an added a
-clause that requires you to use your own servers instead of ours if you do
-modify Tandem.  
-You can also modify this in the configuration file at:
-`agent/tandem/agent/configuration.py`
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
 
 ## Authors
 Team Lightly  
@@ -90,4 +97,3 @@ We are a team of senior Software Engineering students at the University of
 Waterloo.  
 Tandem was created as our [Engineering Capstone Design
 Project](https://uwaterloo.ca/capstone-design).
-

--- a/plugins/sublime/README.md
+++ b/plugins/sublime/README.md
@@ -26,32 +26,38 @@ Tandem users can choose either start a collaborative session or join an existing
 - Any user can leave a session at any time - all other peers can continue working in the session. Simply use `Tandem > Leave Session` from the menu or command palette.
 - If you want to find your session ID again, select `Tandem > Show Session ID` to view your session ID.
 
-
 **Note: You MUST leave an active session before exiting Sublime Text! Due to editor limitations, failure to do so will cause the networking agent to remain alive and consume system resources.** 
 
 ### Advanced Usage
 While commands have GUI hooks (menu option, command palette shortcut), advanced users can also start, join and leave sessions using commands.
 
 Open the command palette (Ctrl + `). From there, use one of the following commands:
-- `view.run_command(“tandem”)` : starts a session and prints the session ID
-- `view.run_command(“tandem_connect”, “abcd-1234”)`: joins a tandem session with the specified session ID (in this case, “abcd-1234”)
-- `view.run_command(“tandem_stop”)`: leaves an existing Tandem session
-- `view.run_command(“tandem_session”)`: displays the current session ID
+- `view.run_command("tandem")` : starts a session and prints the session ID
+- `view.run_command("tandem_connect", "abcd-1234")`: joins a tandem session with the specified session ID (in this case, "abcd-1234")
+- `view.run_command("tandem_stop")`: leaves an existing Tandem session
+- `view.run_command("tandem_session")`: displays the current session ID
+
+## Terms of Service
+By using Tandem, you agree that any modified versions of Tandem will not use
+the rendezvous server hosted by the owners. You must host and use your own copy
+of the rendezvous server. We want to provide a good user experience for Tandem,
+and it would be difficult to do that with modified clients as well.
+
+You can launch the rendezvous server by running `python3 ./rendezvous/main.py`.
+Change the address of the rendezvous server used by the agent in the
+configuration file to point to your server's host. This file is located at:
+`agent/tandem/agent/configuration.py`
 
 ## License
 Copyright (c) 2018 Team Lightly
 
-Licensed under the "Lightly-Modified Apache License", a variant of the Apache
-License, Version 2.0 (the "License"); you may not use this file except in
-compliance with the License. 
-
 See [LICENSE.txt](LICENSE.txt)
 
-This license is essentially the Apache License 2.0, except for an added a
-clause that requires you to use your own servers instead of ours if you do
-modify Tandem.  
-You can also modify this in the configuration file at:
-`agent/tandem/agent/configuration.py`
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
 
 ## Authors
 Team Lightly  

--- a/plugins/vim/README_nvim.md
+++ b/plugins/vim/README_nvim.md
@@ -47,21 +47,27 @@ Please use one of the following commands:
 It is recommended to leave the session before exiting neovim, but that process
 should be automated.
 
+## Terms of Service
+By using Tandem, you agree that any modified versions of Tandem will not use
+the rendezvous server hosted by the owners. You must host and use your own copy
+of the rendezvous server. We want to provide a good user experience for Tandem,
+and it would be difficult to do that with modified clients as well.
+
+You can launch the rendezvous server by running `python3 ./rendezvous/main.py`.
+Change the address of the rendezvous server used by the agent in the
+configuration file to point to your server's host. This file is located at:
+`rplugin/python/tandem_lib/agent/tandem/agent/configuration.py`
 
 ## License
 Copyright (c) 2018 Team Lightly
 
-Licensed under the "Lightly-Modified Apache License", a variant of the Apache
-License, Version 2.0 (the "License"); you may not use this file except in
-compliance with the License. 
-
 See [LICENSE.txt](LICENSE.txt)
 
-This license is essentially the Apache License 2.0, except for an added a
-clause that requires you to use your own servers instead of ours if you do
-modify Tandem.  
-You can also modify this in the configuration file at:
-`agent/tandem/agent/configuration.py`
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
 
 ## Authors
 Team Lightly  

--- a/plugins/vim/README_vim.md
+++ b/plugins/vim/README_vim.md
@@ -40,21 +40,27 @@ Please use one of the following commands:
 It is recommended to leave the session before exiting vim, but that process
 should be automated.
 
+## Terms of Service
+By using Tandem, you agree that any modified versions of Tandem will not use
+the rendezvous server hosted by the owners. You must host and use your own copy
+of the rendezvous server. We want to provide a good user experience for Tandem,
+and it would be difficult to do that with modified clients as well.
+
+You can launch the rendezvous server by running `python3 ./rendezvous/main.py`.
+Change the address of the rendezvous server used by the agent in the
+configuration file to point to your server's host. This file is located at:
+`plugin/tandem_lib/agent/tandem/agent/configuration.py`
+
 ## License
 Copyright (c) 2018 Team Lightly
 
-Licensed under the "Lightly-Modified Apache License", a variant of the Apache
-License, Version 2.0 (the "License"); you may not use this file except in
-compliance with the License. 
-
 See [LICENSE.txt](LICENSE.txt)
 
-This license is essentially the Apache License 2.0, except for an added a
-clause that requires you to use your own servers instead of ours if you do
-modify Tandem.  
-You can also modify this in the configuration file at:
-`agent/tandem/agent/configuration.py`
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
 
+http://www.apache.org/licenses/LICENSE-2.0
 ## Authors
 Team Lightly  
 [Geoffrey Yu](https://github.com/geoffxy), [Jamiboy


### PR DESCRIPTION
There have been [a bunch](https://github.com/typeintandem/tandem/issues/131) [of concerns](https://news.ycombinator.com/item?id=16581851) over the choice of our License. The spirit of the license used was not to stifle the abilities of others to contribute to or distribute Tandem. We received a lot of feedback from the community, and are switching to the unmodified Apache 2.0 license and adding a terms of service to request users of modified versions of Tandem to use their own hosted server.

This PR makes this change, and updates the references to the License used in all the READMEs.